### PR TITLE
Created custom element for banner. Minor style cleanup.

### DIFF
--- a/falls.html
+++ b/falls.html
@@ -9,7 +9,7 @@
       rel="stylesheet"
     />
     <link rel="stylesheet" type="text/css" href="styles/styles.css" />
-    <!-- <script src="scripts/myscripts.js"></script> -->
+    <script src="scripts/components/banner.js"></script>
     <title>Welcome to the Great Outdoors!</title>
   </head>
   <body>
@@ -40,9 +40,7 @@
           </li>
         </ul>
       </nav>
-      <header id="banner">
-        <h1>The Great Outdoors: A Poul Nichols Experience</h1>
-      </header>
+      <banner-component></banner-component>
       <div class="content">
         <main>
           <div class="entry">

--- a/ferry.html
+++ b/ferry.html
@@ -9,7 +9,7 @@
       rel="stylesheet"
     />
     <link rel="stylesheet" type="text/css" href="styles/styles.css" />
-    <!-- <script src="scripts/myscripts.js"></script> -->
+    <script src="scripts/components/banner.js"></script>
     <title>Welcome to the Great Outdoors!</title>
   </head>
   <body>
@@ -40,9 +40,7 @@
           </li>
         </ul>
       </nav>
-      <header id="banner">
-        <h1>The Great Outdoors: A Poul Nichols Experience</h1>
-      </header>
+      <banner-component></banner-component>
       <div class="content">
         <main>
           <div class="entry">

--- a/forest.html
+++ b/forest.html
@@ -9,7 +9,7 @@
       rel="stylesheet"
     />
     <link rel="stylesheet" type="text/css" href="styles/styles.css" />
-    <!-- <script src="scripts/myscripts.js"></script> -->
+    <script src="scripts/components/banner.js"></script>
     <title>Welcome to the Great Outdoors!</title>
   </head>
   <body>
@@ -40,9 +40,7 @@
           </li>
         </ul>
       </nav>
-      <header id="banner">
-        <h1>The Great Outdoors: A Poul Nichols Experience</h1>
-      </header>
+      <banner-component></banner-component>
       <div class="content">
         <main>
           <div class="entry">

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
       rel="stylesheet"
     />
     <link rel="stylesheet" type="text/css" href="styles/styles.css" />
-    <!-- <script src="scripts/myscripts.js"></script> -->
+    <script src="scripts/components/banner.js"></script>
     <title>Welcome to the Great Outdoors!</title>
   </head>
   <body>
@@ -40,9 +40,7 @@
           </li>
         </ul>
       </nav>
-      <header id="banner">
-        <h1>The Great Outdoors: A Poul Nichols Experience</h1>
-      </header>
+      <banner-component></banner-component>
       <div class="content">
         <main>
           <div class="entry">
@@ -102,7 +100,6 @@
           <li>©2025 Poul Nichols</li>
           <li><a href="">Contact</a></li>
           <li><a href="">Terms</a></li>
-          <!-- <li><a href=""></a></li> -->
           <li>Enjoying The Great Outdoors? <a href="">Buy me a coffee</a></li>
         </ul>
       </footer>

--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
   <body>
     <div id="wrapper">
       <nav id="sidebar">
-        <center><img id="logo" src="images/logo.png" alt="Great Outdoors" /></center>
+        <img id="logo" src="images/logo.png" alt="Great Outdoors" />
         <ul>
           <li onclick="location.href="./index.html';">
             <a href="index.html">Great Outdoors</a>

--- a/lake.html
+++ b/lake.html
@@ -9,7 +9,7 @@
       rel="stylesheet"
     />
     <link rel="stylesheet" type="text/css" href="styles/styles.css" />
-    <!-- <script src="scripts/myscripts.js"></script> -->
+    <script src="scripts/components/banner.js"></script>
     <title>Welcome to the Great Outdoors!</title>
   </head>
   <body>
@@ -40,9 +40,7 @@
           </li>
         </ul>
       </nav>
-      <header id="banner">
-        <h1>The Great Outdoors: A Poul Nichols Experience</h1>
-      </header>
+      <banner-component></banner-component>
       <div class="content">
         <main>
           <div class="entry">

--- a/mountain.html
+++ b/mountain.html
@@ -9,7 +9,7 @@
       rel="stylesheet"
     />
     <link rel="stylesheet" type="text/css" href="styles/styles.css" />
-    <!-- <script src="scripts/myscripts.js"></script> -->
+    <script src="scripts/components/banner.js"></script>
     <title>Welcome to the Great Outdoors!</title>
   </head>
   <body>
@@ -40,9 +40,7 @@
           </li>
         </ul>
       </nav>
-      <header id="banner">
-        <h1>The Great Outdoors: A Poul Nichols Experience</h1>
-      </header>
+      <banner-component></banner-component>
       <div class="content">
         <main>
           <div class="entry">

--- a/park.html
+++ b/park.html
@@ -9,7 +9,7 @@
       rel="stylesheet"
     />
     <link rel="stylesheet" type="text/css" href="styles/styles.css" />
-    <!-- <script src="scripts/myscripts.js"></script> -->
+    <script src="scripts/components/banner.js"></script>
     <title>Welcome to the Great Outdoors!</title>
   </head>
   <body>
@@ -40,9 +40,7 @@
           </li>
         </ul>
       </nav>
-      <header id="banner">
-        <h1>The Great Outdoors: A Poul Nichols Experience</h1>
-      </header>
+      <banner-component></banner-component>
       <div class="content">
         <main>
           <div class="entry">

--- a/scripts/components/banner.js
+++ b/scripts/components/banner.js
@@ -1,0 +1,17 @@
+class Banner extends HTMLElement {
+  constructor() {
+    super();
+  }
+
+  connectedCallback() {
+    this.setAttribute("style", "display: contents;")
+
+    this.innerHTML = `
+          <header id="banner">
+          <h1>The Great Outdoors: A Poul Nichols Experience</h1>
+      </header>
+      `;
+  }
+}
+
+customElements.define("banner-component", Banner);

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -47,10 +47,6 @@ html, body {
   line-height: 1.4;
 }
 
-header, footer {
-  box-sizing: border-box;
-}
-
 h1, h2, h3, h4, h5, h6 {
   font-family: var(--heading-font);
   margin-top: 0;
@@ -117,10 +113,10 @@ nav#sidebar {
 than viewport despite my best efforts. */
 
 img#logo {
-  /* border: 2px solid var(--color-gold); */
   height: calc(150px - var(--space-med));
   border-radius: var(--corner-radius);
   display: block;
+  margin: 0 auto;
   padding-bottom: var(--space-xs);
 }
 

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -29,10 +29,13 @@
 
 }
 
+* {
+  box-sizing: border-box;
+}
+
 /* Reset */
 
 html, body {
-  box-sizing: border-box;
   margin: 0;
   padding: 0;
   border: 0;
@@ -80,7 +83,6 @@ header#banner {
   background-repeat: no-repeat;
   background-size: 100%;
   background-position: 50% 30%;
-
   display: flex;
   align-items: center;
   justify-content: center;

--- a/template.html
+++ b/template.html
@@ -9,7 +9,7 @@
       rel="stylesheet"
     />
     <link rel="stylesheet" type="text/css" href="styles/styles.css" />
-    <!-- <script src="scripts/myscripts.js"></script> -->
+    <script src="scripts/components/banner.js"></script>
     <title>Welcome to the Great Outdoors!</title>
   </head>
   <body>
@@ -40,9 +40,7 @@
           </li>
         </ul>
       </nav>
-      <header id="banner">
-        <h1>The Great Outdoors: A Poul Nichols Experience</h1>
-      </header>
+      <banner-component></banner-component>
       <div class="content">
         <main>
           <div class="entry">


### PR DESCRIPTION
This is mainly a proof of concept: I've converted the banner into a custom element. I was having the darnedest time figuring out why the new component was unaffected by the grid layout - applying `display: contents;` fixed it, though I'm still not quite sure why it was necessary or whether that's the best fix here.

Closes #76 

### Minor style cleanup
- I replaced the `<center>` tag surrounding the logo with `margin: 0 auto;` in the stylesheet. (Forgot to do this on pages other than home - will address when converting navbar to a component)
- I added `* { box-sizing: border-box; }` and deleted other `border-box` declarations in the stylesheet. This shrank navbar `<li>` elements by a couple pixels.